### PR TITLE
Added: RISCV64 support

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -18,6 +18,7 @@ builds:
       - amd64
       - arm
       - arm64
+      - riscv64
     goarm:
       - "6"
       - "7"
@@ -26,6 +27,10 @@ builds:
         goarch: arm64
       - goos: windows
         goarch: arm
+      - goos: windows
+        goarch: riscv64
+      - goos: darwin
+        goarch: riscv64
 changelog:
   filters:
     exclude:


### PR DESCRIPTION
I would like to add RISCV64 in project [docker-minecraft-server](https://github.com/itzg/docker-minecraft-server).
So this is the second step!